### PR TITLE
Add Force TV cam button to trigger F6 camera switch

### DIFF
--- a/ACTTV/ACTTV.py
+++ b/ACTTV/ACTTV.py
@@ -6,7 +6,7 @@ import ac
 from . import config, state
 from .focus import focus_best_by_proximity
 from .scheduler import schedule_next_switch
-from .ui import toggle_callback, update_ui
+from .ui import toggle_callback, force_tv_cam, update_ui
 
 
 def acMain(ac_version):
@@ -23,6 +23,11 @@ def acMain(ac_version):
     ac.setPosition(state.toggle_button, 10, 55)
     ac.setSize(state.toggle_button, 120, 25)
     ac.addOnClickedListener(state.toggle_button, toggle_callback)
+
+    state.force_tv_button = ac.addButton(state.app_window, "Force TV cam")
+    ac.setPosition(state.force_tv_button, 140, 55)
+    ac.setSize(state.force_tv_button, 120, 25)
+    ac.addOnClickedListener(state.force_tv_button, force_tv_cam)
 
     state.camera_label = ac.addLabel(state.app_window, "Camera: TV/manual (set with F2/F5/F6) | Mode: Proximity")
     ac.setPosition(state.camera_label, 10, 85)

--- a/ACTTV/state.py
+++ b/ACTTV/state.py
@@ -5,6 +5,7 @@ app_window = None
 status_label = None
 camera_label = None
 toggle_button = None
+force_tv_button = None
 
 next_switch_time = 0.0
 current_car_id = -1

--- a/ACTTV/ui.py
+++ b/ACTTV/ui.py
@@ -1,6 +1,7 @@
 """User interface helpers for the ACTTV app."""
 
 import time
+import ctypes
 import ac
 
 from . import config, state
@@ -23,6 +24,9 @@ def update_ui():
     if state.toggle_button is not None:
         ac.setText(state.toggle_button, "Pause" if state.enabled else "Resume")
 
+    if getattr(state, "force_tv_button", None) is not None:
+        ac.setText(state.force_tv_button, "Force TV cam")
+
 
 def toggle_callback(*args):
     """Pause/Resume button callback."""
@@ -31,4 +35,14 @@ def toggle_callback(*args):
     if state.enabled:
         schedule_next_switch()
     update_ui()
+
+
+def force_tv_cam(*args):
+    """Force switch to TV camera by simulating the F6 key."""
+    ac.log("[{}] Forcing TV camera".format(config.APP_NAME))
+    user32 = ctypes.windll.user32
+    # Press
+    user32.keybd_event(0x75, 0, 0, 0)
+    # Release
+    user32.keybd_event(0x75, 0, 2, 0)
 


### PR DESCRIPTION
## Summary
- add a "Force TV cam" UI button
- button sends an F6 keypress to Assetto Corsa using Windows APIs

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b5a7f796a483328d0c9f801a562b63